### PR TITLE
upgrade versions of internal project dependecies in case of release ALL ...

### DIFF
--- a/lib/release-helper.js
+++ b/lib/release-helper.js
@@ -36,6 +36,16 @@ module.exports = function (ctx) {
                 // save new version in bower component descriptor
                 bowerComponent.content.version = bowerComponent.version = requestedVersion.toString();
 
+                // use new version for internal project dependencies
+                if (ctx.cmdOption(ctx.CMD_OPTIONS.ALL)){
+                    for(var dependencyName in bowerComponent.content.dependencies) {
+                        if (ctx.availableBowerComponents.hasOwnProperty(dependencyName)){
+                            ctx.logVerbose('Updating version for dependency "' + dependencyName + '" from: ' + bowerComponent.content.dependencies[dependencyName] + ' to: ' + bowerComponent.version);
+                            bowerComponent.content.dependencies[dependencyName] = bowerComponent.version;
+                        }
+                    }
+                }
+
                 ctx.log(ctx.grunt.template.process('Releasing <%= name %>#<%= version %> ...', {data: bowerComponent}));
 
                 // once new version number is known, we have store modified bower.json file and finalize release


### PR DESCRIPTION
When user use --all flag, internal project dependencies should be synchronizes with new version. 
